### PR TITLE
Add token data and stats features

### DIFF
--- a/style.css
+++ b/style.css
@@ -61,6 +61,12 @@ button {
   color: #10b981;
   margin-left: 8px;
 }
+.price-change {
+  font-size: 0.9rem;
+  margin-left: 4px;
+}
+.price-change.positive { color: #16a34a; }
+.price-change.negative { color: #dc2626; }
 
 .section {
   margin-top: 32px;


### PR DESCRIPTION
## Summary
- fetch metadata, price, analytics and more on search
- display market info, price change and creation data
- embed Moralis chart widget with token address
- show top holders with links and holder change with timeframe
- list recent swaps with wallet, time and link
- compute buy/sell ratio with timeframe
- add styling for price change indicator

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f1e223010832b889e00ad33958786